### PR TITLE
Add Docker runtime support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+node_modules
+built
+src
+.git
+.gitignore
+.vscode
+.idea
+TankHuntNode.code-workspace
+TankHuntNode.sublime-project
+TankHuntNode.sublime-workspace
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@
 /built/
 /node_modules/
 /src/client/assets/preparing
+/npm-debug.log*
+/yarn-debug.log*
+/yarn-error.log*
+/tankhunt.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:16-bookworm-slim
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+
+COPY dist ./dist
+
+ENV NODE_ENV=production
+ENV TANKHUNT_PORT=8080
+
+EXPOSE 8080
+
+CMD ["node", "dist/server/app.js"]

--- a/README.md
+++ b/README.md
@@ -22,3 +22,23 @@ This game participated in a competition held by itnetwork.cz.
 5) Run the server:
     `node dist/server/app.js`
 
+## Docker
+
+Build the image locally from the repository root:
+
+```bash
+docker build -t tankhunt:local .
+```
+
+Run the container and publish the game on port 8080:
+
+```bash
+docker run --rm -p 8080:8080 tankhunt:local
+```
+
+To use a different host port, change only the published port on the left side. For example, this exposes the game on port 8090:
+
+```bash
+docker run --rm -p 8090:8080 tankhunt:local
+```
+


### PR DESCRIPTION
## Summary

Adds basic Docker runtime support for Tankhunt.

## Changes

- add `Dockerfile` for running the prebuilt `dist` output
- add `.dockerignore` to keep the image context minimal
- document Docker build and run usage in `README.md`
- ignore local runtime log files in `.gitignore`

## Verification

- built image locally with `docker build -t tankhunt:local .`
- verified the container starts and serves the app successfully